### PR TITLE
Option to specify base directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,23 @@ npm i -D fly-jade
 exports.jade = function* () {
   yield this
     .source('src/*.jade')
-    .jade()
+    .jade({base: 'src'})
     .target('dist');
 };
+```
+
+#### Options
+
+- passing the base directory as `base` is necessary for jade to resolve relative includes/excludes
+- e.g. if we have a file `src/index.jade` which refers to a layout file `src/layouts/default.jade`:
+
+```jade
+extends layouts/default
+
+block content
+  .row
+    .col-sm-12
+      h1 Welcome
 ```
 
 # License

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = function() {
   this.filter("jade", (data, options) => ({
-    css: require("jade").render(data.toString(), options), ext: ".html"
+    css: require("jade").render(data.toString(), {...options, filename: options.base ? `${options.base}/${options.filename}` : options.filename}), ext: ".html"
   }))
 }


### PR DESCRIPTION
#### What's this PR do?

The filename option is "used in exceptions, and required for relative includes and extends", however Jade needs to know the base directory also otherwise it wont be able to find relative include/excludes and compilation fails.
