### PR TITLE
Remove unnecessary dependencies from distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,7 @@
   "repository": "https://github.com/sugarshin/fly-jade",
   "main": "index.js",
   "files": [
-    "test",
-    "package.json",
-    "index.js",
-    "README.md"
+    "index.js"
   ],
   "keywords": [
     "fly",
@@ -31,11 +28,7 @@
     "url": "http://github.com/sugarshin"
   },
   "dependencies": {
-    "eslint": "^0.21.2",
-    "fly": "^0.1.11",
-    "jade": "^1.11.0",
-    "tap-spec": "^4.0.2",
-    "tape": "^4.2.0"
+    "jade": "^1.11.0"
   },
   "devDependencies": {
     "eslint": "^0.21.2",


### PR DESCRIPTION
Excludes unnecessary files from redist package. The average user does
not need tests in the package. They need developers.

About [README.md and LICENSE](https://docs.npmjs.com/files/package.json#files):

> Certain files are always included, regardless of settings:
> - package.json
> - README (and its variants)
> - CHANGELOG (and its variants)
> - LICENSE / LICENCE
